### PR TITLE
fix(jest): interface and string token combination

### DIFF
--- a/src/lib/reflector.service.spec.ts
+++ b/src/lib/reflector.service.spec.ts
@@ -34,7 +34,7 @@ describe('Reflector Service TestBed', () => {
 
   describe('scenario: successfully reflecting dependencies and tokens', () => {
     describe('when not overriding any of the class dependencies', () => {
-      let result: Map<string | Type<unknown>, Type<unknown>>;
+      let result: Map<string | Type<unknown>, string | Type<unknown>>;
 
       beforeAll(() => {
         getMetadataStub.mockImplementation(VALID_IMPL);

--- a/src/lib/reflector.service.ts
+++ b/src/lib/reflector.service.ts
@@ -5,42 +5,46 @@ export interface CustomToken {
   param: Type | { forwardRef: () => Type } | string;
 }
 
+export type TokenOrType = string | Type<unknown>;
+export type ClassDependencies = Map<TokenOrType, Type<unknown>>;
+
 export class ReflectorService {
   private static readonly INJECTED_TOKENS_METADATA = 'self:paramtypes';
   private static readonly PARAM_TYPES_METADATA = 'design:paramtypes';
 
   public constructor(private readonly reflector: typeof Reflect) {}
 
-  public reflectDependencies(targetClass: Type): Map<string | Type<unknown>, Type<unknown>> {
-    const classDependencies = new Map<string | Type<unknown>, Type<unknown>>();
+  public reflectDependencies(targetClass: Type): ClassDependencies {
+    const classDependencies = new Map<TokenOrType, Type<unknown>>();
 
     const types = this.reflectParamTypes(targetClass);
     const tokens = this.reflectParamTokens(targetClass);
 
-    const duplicates = ReflectorService.findDuplicates([...types]).map((typeOrToken) =>
-      typeof typeOrToken === 'string' ? typeOrToken : typeOrToken.name
-    );
+    types.forEach((type, index) => {
+      const token = ReflectorService.findToken(tokens, index);
+      const isObjectType = type && type.name === 'Object';
 
-    types.forEach((type: Type<unknown>, index: number) => {
-      if (type.name === 'Object' || duplicates.includes(type.name)) {
-        const token = ReflectorService.findToken(tokens, index);
-
-        if (!token) {
-          if (type.name === 'Object') {
-            throw new Error(
-              `'${targetClass.name}' is missing a token for the dependency at index [${index}], did you forget to inject it using @Inject()?`
-            );
-          } else {
-            throw new Error(`'${targetClass.name}' includes non-unique types/tokens dependencies`);
+      if (token) {
+        const ref = ReflectorService.resolveRefFromToken(token);
+        if (isObjectType) {
+          if (typeof ref !== 'string') {
+            classDependencies.set(ref, ref);
+            return;
           }
         }
-
-        const ref = typeof token === 'object' && 'forwardRef' in token ? token.forwardRef() : token;
-
-        classDependencies.set(ref, type);
-      } else {
-        classDependencies.set(type, type);
+        if (type) {
+          classDependencies.set(ref, type);
+          return;
+        }
       }
+      if (type && !isObjectType) {
+        classDependencies.set(type, type);
+        return;
+      }
+
+      throw new Error(
+        `'${targetClass.name}' is missing a token for the dependency at index [${index}], did you forget to inject it using @Inject()?`
+      );
     });
 
     return classDependencies;
@@ -50,31 +54,19 @@ export class ReflectorService {
     return this.reflector.getMetadata(ReflectorService.INJECTED_TOKENS_METADATA, targetClass) || [];
   }
 
-  private reflectParamTypes(targetClass: Type): Type[] {
+  private reflectParamTypes(targetClass: Type): Array<Type | undefined> {
     return this.reflector.getMetadata(ReflectorService.PARAM_TYPES_METADATA, targetClass) || [];
   }
 
-  private static findToken(
-    list: CustomToken[],
-    index: number
-  ): Type | { forwardRef: () => Type } | string | undefined {
+  private static findToken(list: CustomToken[], index: number): Token | undefined {
     const record = list.find((element) => element.index === index);
 
     return record?.param;
   }
 
-  private static findDuplicates(typesOrToken: (Type | string)[]) {
-    const items = [...typesOrToken.sort()];
-
-    let index = items.length;
-    const duplicates = [];
-
-    while (index--) {
-      items[index] === items[index - 1] &&
-        duplicates.indexOf(items[index]) == -1 &&
-        duplicates.push(items[index]);
-    }
-
-    return duplicates;
+  private static resolveRefFromToken(token: Token): string | Type<any> {
+    return typeof token === 'object' && 'forwardRef' in token ? token.forwardRef() : token;
   }
 }
+
+type Token = Type | { forwardRef: () => Type } | string;

--- a/src/lib/test-bed-resolver.ts
+++ b/src/lib/test-bed-resolver.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 import { DeepPartial } from 'ts-essentials';
 import { MockFunction, Override, UnitTestBed, Type } from './types';
 import { MockResolver } from './mock-resolver';
-import { ReflectorService } from './reflector.service';
+import { ReflectorService, TokenOrType } from './reflector.service';
 
 import Mocked = jest.Mocked;
 
@@ -28,7 +28,7 @@ export interface TestBedResolver<TClass = any> {
 }
 
 export class TestBedResolver<TClass = any> {
-  private readonly dependencies = new Map<Type | string, DeepPartial<unknown>>();
+  private readonly dependencies = new Map<TokenOrType, Type<unknown>>();
   private readonly depNamesToMocks = new Map<Type | string, Mocked<any>>();
 
   public constructor(


### PR DESCRIPTION
Fixed the way tokens are reflected. Now it won't assume the type is defined and will make the best effort to use the token or type name. There are still scenarios that `ref -> Object` is left, that I think should throw but that's for another PR.

I removed the duplicates check there because I was not sure what it should do (I can bring it back but I need to know how to integrate it correctly).

I also updated some tests and types because I had false positives during development.

Resolves #25